### PR TITLE
Docker Desktop доступен для всех популярных OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Oh My BackEnd
 1. установить [docker](https://www.docker.com/products/docker-desktop) <kbd>junior</kbd>
 1. запустить контейнер с Linux Ubuntu, последней [LTS версией](https://ru.wikipedia.org/wiki/Список_версий_Ubuntu#Выпуски). Запустить bash (консоль) контейнера. <kbd>junior</kbd>
 1. установить удобное приложение для управления образами и контейнерами [Kitematic](https://kitematic.com/), [Portainer](https://hub.docker.com/r/portainer/portainer/) и т.д. 
-   Либо сродниться с консольными командами docker. На некоторых OC десктопный docker уже имеет [свой dashboard](https://docs.docker.com/desktop/dashboard/) для управления образами и контейнерами. <kbd>junior</kbd>
+   Либо сродниться с консольными командами docker. docker-desktop уже имеет [свой dashboard](https://docs.docker.com/desktop/dashboard/) для управления образами и контейнерами. <kbd>junior</kbd>
 1. docker compose для поднятия кластера контейнеров. <kbd>middle</kbd>
    > Для рабочего приложения, как правило, требуется несколько различных сервисов (база данных, кэшер, http-сервер и т.д.)
    > и всё это упаковать в один docker контейнер будет проблемно, просто из-за специфики работы самой виртуализации.


### PR DESCRIPTION
https://www.docker.com/blog/the-magic-of-docker-desktop-is-now-available-on-linux/

C 10 мая 2022 года docker-desktop доступен на всех популярных OS, и сноска о доступе "На некоторых" уже не актуальна